### PR TITLE
Fix observing-elixir-with-lightstep configuration

### DIFF
--- a/priv/blogs/2022/08-03-observing-elixir-with-lightstep.md
+++ b/priv/blogs/2022/08-03-observing-elixir-with-lightstep.md
@@ -70,11 +70,13 @@ First we'll add the required dependencies into our `mix.exs` file for producing 
 >
 > You'll notice a number of OpenTelemetry libraries are in `rc`, or release-candidate status. Using release candidates carries some inherent risk, but are generally safe to use. They are put in this status to indicate that there are some changes that have not fully stabilized, but they are nearing a major release.
 
+Note `opentelemetry_exporter` has to be placed first in the dependencies list.
+
 ```elixir
 # mix.exs
+{:opentelemetry_exporter, "~> 1.0"},
 {:opentelemetry, "~> 1.0"},
 {:opentelemetry_api, "~> 1.0"},
-{:opentelemetry_exporter, "~> 1.0", only: :prod},
 ```
 
 Additionally, you should install instrumentation libraries for any of the popular libraries and frameworks you may be using
@@ -131,6 +133,8 @@ Before we start sending data, we need to add a few configurations to our app
 
 Although observability is important, if it fails it shouldn't take your app down with it! To ensure this is the case, we need to make sure `opentelemetry` runs in temporary mode
 
+We also need to put `opentelemetry_exporter` before other `opentelemetry` in the release's applications list, to make sure the applications it depends on are started properly.
+
 ```elixir
 # mix.exs
 
@@ -139,7 +143,11 @@ def project do
     ...,
     releases: [
       my_app: [
-          applications: [my_app: :permanent, opentelemetry: :temporary]
+        applications: [
+          my_app: :permanent,
+          opentelemetry_exporter: :permanent,
+          opentelemetry: :temporary
+        ]
       ]
     ]
   ]


### PR DESCRIPTION
- put opentelemetry_exporter first in the dependencies so it is started
  first
- remove opentelemetry_exporter `only: :prod` to fix dev and test runs
- put opentelemetry_exporter first in release applications to make sure
  its dependent applications are properly started

This avoids these runtime errors:
```
19:13:38.134 [debug] OTLP exporter failed to initialize: exception throw: {application_either_not_started_or_not_ready,
                     tls_certificate_check}
  in function  tls_certificate_check_shared_state:latest_shared_state_key/0 (/home/flupke/src/jitter/jitter.video/elixir_backend/deps/tls_certificate_check/src/tls_certificate_check_shared_state.erl, line 338)
  in call from tls_certificate_check_shared_state:get_latest_shared_state/0 (/home/flupke/src/jitter/jitter.video/elixir_backend/deps/tls_certificate_check/src/tls_certificate_check_shared_state.erl, line 320)
  in call from tls_certificate_check_shared_state:authoritative_certificate_values/0 (/home/flupke/src/jitter/jitter.video/elixir_backend/deps/tls_certificate_check/src/tls_certificate_check_shared_state.erl, line 126)
  in call from tls_certificate_check:options/1 (/home/flupke/src/jitter/jitter.video/elixir_backend/deps/tls_certificate_check/src/tls_certificate_check.erl, line 78)
  in call from opentelemetry_exporter:parse_endpoint/2 (/home/flupke/src/jitter/jitter.video/elixir_backend/deps/opentelemetry_exporter/src/opentelemetry_exporter.erl, line 326)
  in call from opentelemetry_exporter:endpoint/2 (/home/flupke/src/jitter/jitter.video/elixir_backend/deps/opentelemetry_exporter/src/opentelemetry_exporter.erl, line 298)
  in call from lists:filtermap_1/2 (lists.erl, line 1417)
  in call from opentelemetry_exporter:init/1 (/home/flupke/src/jitter/jitter.video/elixir_backend/deps/opentelemetry_exporter/src/opentelemetry_exporter.erl, line 194)
```