### PR TITLE
Update 08-03-observing-elixir-with-lightstep.md

### DIFF
--- a/priv/blogs/2022/08-03-observing-elixir-with-lightstep.md
+++ b/priv/blogs/2022/08-03-observing-elixir-with-lightstep.md
@@ -194,9 +194,7 @@ if System.get_env("DEBUG_OTEL") == "true" do
       exporter: {:otel_exporter_stdout, []}
     }
 else
-  config :opentelemetry,
-    :tracer,
-    :otel_tracer_noop
+  config :opentelemetry, traces_exporter: :none
 end
 ```
 


### PR DESCRIPTION
Disabling traces in `dev.exs` using `:otel_tracer_noop` didn't work for me, but reading the OpenTelemetry exporter [docs](https://hexdocs.pm/opentelemetry_exporter/readme.html#options-to-span-processor) they suggested `config :opentelemetry, traces_exporter: :none`