### PR TITLE
Updated OpenTelemetry semantic conventions url

### DIFF
--- a/priv/blogs/2022/08-03-observing-elixir-with-lightstep.md
+++ b/priv/blogs/2022/08-03-observing-elixir-with-lightstep.md
@@ -156,7 +156,7 @@ end
 
 2. Set your runtime specific attributes for your production environment
 
-My application currently runs in [Fly.io](https://fly.io). In the startup script for my Elixir release, I add the following annotations so that every span has information about the server and environment it is executed in. Note that there are more options that you can set, see the [OpenTelemetry semantic conventions for the cloud](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/cloud.md)
+My application currently runs in [Fly.io](https://fly.io). In the startup script for my Elixir release, I add the following annotations so that every span has information about the server and environment it is executed in. Note that there are more options that you can set, see the [OpenTelemetry semantic conventions for the cloud](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md)
 
 ```bash
 # rel/overlays/bin/server


### PR DESCRIPTION
While going over the article, I noticed that the semantic conventions moved to its own repo. We don't have a link to `cloud` anymore. We now have `Cloud Providers` and `CloudEvents`, but I'm suggesting linking to the main `README.md` file and let readers look into whatever convention they need.

... and thanks for the content you share on your website!